### PR TITLE
[Composer] Bumped packages versions to the latest stable installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=7.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "symfony/flex": "^1.3.1"
+        "symfony/flex": "^1.11.0"
     },
     "flex-require": {
         "sensio/framework-extra-bundle": "^5.6.1",
@@ -40,7 +40,7 @@
     },
     "flex-require-dev": {
         "symfony/debug-pack": "*",
-        "symfony/maker-bundle": "^1.0",
+        "symfony/maker-bundle": "^1.26.1",
         "symfony/profiler-pack": "*",
         "symfony/test-pack": "*"
     },


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3@rc`
| **BC breaks**                          | no
| **Doc needed**                       | no

This PR updates packages in composer.json to use the latest installed for composer memory optimization.
Keeping `extra.symfony.require` as `5.2.*` to be aligned with SF skeleton.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review
