### PR TITLE
[Composer] Bumped Symfony version to 5.3.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "symfony/notifier": "*",
         "symfony/orm-pack": "*",
         "symfony/process": "*",
+        "symfony/runtime": "*",
         "symfony/security-bundle": "*",
         "symfony/serializer-pack": "*",
         "symfony/string": "*",
@@ -82,7 +83,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": true,
-            "require": "5.2.*",
+            "require": "5.3.*",
             "endpoint": "https://flex.ibexa.co"
         },
         "branch-alias": {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Type**                                   | n/a
| **Target Ibexa version** | v3.3 and 4.0
| **BC breaks**                          | no
| **Doc needed**                       | no

Bumped the Symfony version used to the recently released 5.3.

I had to add the symfony/runtime requirement (it's also present in https://github.com/symfony/website-skeleton/blob/5.3/composer.json#L30).

There are other differences between these two skeletons:
1) sensio/framework-extra-bundle is using different major: https://github.com/symfony/website-skeleton/blob/5.3/composer.json#L30 (we have `"sensio/framework-extra-bundle": "^5.6.1")
2) We still have `"doctrine/doctrine-bundle": "~2.3.2"` - added in https://github.com/ibexa/website-skeleton/pull/3 , not sure if it's still needed.

Currently this PR fails to install with:
```
!!  In CheckExceptionOnInvalidReferenceBehaviorPass.php line 86:
!!
!!    The service "ezpublish_rest.security.authentication.listener.session.ezpubl
!!    ish_front" has a dependency on a non-existent service "session.storage". Di
!!    d you mean this: "session.storage.factory.native"?
```
which seems related to https://github.com/symfony/symfony/pull/40048

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review (ping `@ibexa/engineering`).
