### PR TITLE
[Composer] Added symfony/thanks and ibexa/post-install to allowed plu…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,9 @@
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "symfony/flex": true,
-            "symfony/runtime": true
+            "symfony/runtime": true,
+            "symfony/thanks": true,
+            "ibexa/post-install": true
         },
         "optimize-autoloader": true,
         "preferred-install": {


### PR DESCRIPTION
Adding these plugins to the list of allowed one to avoid prompts during installation:
```
Do you trust "symfony/thanks" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
ibexa/post-install contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "ibexa/post-install" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
```

The `allow-plugins` is a new feature from Composer 2.2: https://getcomposer.org/doc/06-config.md#allow-plugins