### PR TITLE
[composer] Limit phpunit/phpunit version to ^9 || ^10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "doctrine/doctrine-bundle": "^2.4"
     },
     "require-dev": {
+        "phpunit/phpunit": "^9 || ^10"
     },
     "flex-require-dev": {
         "symfony/debug-pack": "*",


### PR DESCRIPTION
By default `symfony/test-pack` will install highest available phpunit version (10 at the time of writing this) which is incompatible with PHP versions lower than 8.1. In order to allow for easier Ibexa DXP installation this requirement should be added to avoid downgrading phpunit explicitly when installing Ibexa DXP.