### PR TITLE
[Composer] Created new lightweight skeleton based on symfony/skeleton

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,52 +12,21 @@
         "symfony/flex": "^1.17|^2"
     },
     "flex-require": {
-        "sensio/framework-extra-bundle": "^6.1",
-        "symfony/asset": "*",
         "symfony/console": "*",
         "symfony/dotenv": "*",
-        "symfony/dom-crawler": "*",
-        "symfony/error-handler": "*",
-        "symfony/expression-language": "*",
-        "symfony/form": "*",
         "symfony/framework-bundle": "*",
-        "symfony/http-client": "*",
-        "symfony/intl": "*",
-        "symfony/mailer": "*",
-        "symfony/mime": "*",
-        "symfony/monolog-bundle": "^3.1",
-        "symfony/notifier": "*",
-        "symfony/orm-pack": "*",
-        "symfony/password-hasher": "*",
-        "symfony/process": "*",
         "symfony/runtime": "*",
-        "symfony/security-bundle": "*",
-        "symfony/serializer-pack": "*",
-        "symfony/string": "*",
-        "symfony/translation": "*",
-        "symfony/twig-bridge": "*",
-        "symfony/twig-pack": "*",
-        "symfony/validator": "*",
-        "symfony/var-exporter": "*",
-        "symfony/web-link": "*",
-        "symfony/yaml": "*",
-        "doctrine/doctrine-bundle": "^2.4"
+        "symfony/yaml": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9 || ^10"
-    },
-    "flex-require-dev": {
-        "symfony/debug-pack": "*",
-        "symfony/maker-bundle": "^1.0",
-        "symfony/profiler-pack": "*",
-        "symfony/test-pack": "*"
     },
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
+            "ibexa/post-install": true,
+            "php-http/discovery": true,
             "symfony/flex": true,
-            "symfony/runtime": true,
-            "ibexa/post-install": true
+            "symfony/runtime": true
         },
         "optimize-autoloader": true,
         "preferred-install": {
@@ -81,7 +50,8 @@
         "symfony/polyfill-php72": "*"
     },
     "scripts": {
-        "auto-scripts": [],
+        "auto-scripts": [
+        ],
         "post-install-cmd": [
             "@auto-scripts"
         ],
@@ -95,8 +65,8 @@
     "extra": {
         "symfony": {
             "allow-contrib": true,
-            "endpoint": "https://api.github.com/repos/ibexa/recipes-dev/contents/index.json?ref=flex/main",
-            "require": "5.4.*"
+            "require": "5.4.*",
+            "endpoint": "https://api.github.com/repos/ibexa/recipes-dev/contents/index.json?ref=flex/main"
         },
         "branch-alias": {
             "dev-main": "3.3.x-dev"


### PR DESCRIPTION
The idea behind website-skeleton was that it'll strictly match `symfony/website-skeleton` with updated flex endpoint field. In the meantime website-skeleton became abandoned in favor of `symfony/skeleton`. Our installation procedure comes in two phases - first installs website-skeleton and then we install `ibexa/{oss, content, experience, commerce}` on top of it. This can be difficult to maintain because there is a high chance website-skeleton will install incompatible packages due to unrestricted constraints `*`. It was an issue on a few occasions in the past i.e. with PHPUnit 10 release and now with `doctrine/annotations` v2 installed instead of v1 we require.

New website-skeleton has minimal set of packages to avoid installing some packages like Doctrine prematurely.