### PR TITLE
IBX-8470: Upgraded codebase to Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "symfony/flex": "^1.17|^2"

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": true,
-            "require": "5.4.*",
+            "require": "6.4.*",
             "endpoint": "https://api.github.com/repos/ibexa/recipes-dev/contents/index.json?ref=flex/main"
         },
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=8.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "symfony/flex": "^1.17|^2"
+        "symfony/flex": "^2"
     },
     "flex-require": {
         "symfony/console": "*",


### PR DESCRIPTION
> [!CAUTION]
> This is a part of bigger set of changes, to be merged together when ready
> - [x] :exclamation:  **Remove TMP commits before merge** :exclamation:

| :ticket: Issue | IBX-8470 |
|----------------|-----------|

#### Description:

This PR bumps Symfony to v6 with codebase upgrades.

Key changes:

- [x] Bumped PHP version to 8.3
- [x] Restricted packages listed in "symfony/symfony" to "6.4.*"
- [x] Bump symfony/flex to 2.x

#### QA:

N/A

#### Documentation:

N/A


