### PR TITLE
IBX-10228: Bumped symfony/* to ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": true,
-            "require": "7.2.*",
+            "require": "7.3.*",
             "endpoint": "https://api.github.com/repos/ibexa/recipes-dev/contents/index.json?ref=flex/main"
         },
         "branch-alias": {


### PR DESCRIPTION
| :ticket: Issue | IBX-10228    |
|----------------|--------------|

#### Description:
This PR updates all symfony/* dependencies to ^7.3.

#### For QA:
N/A

#### Documentation:
N/A

