### PR TITLE
IBX-11405: Ignore PhpSpreadSheet issues in v3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,12 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "ignore": {
+                "phpoffice/phpspreadsheet": "Fixes don't exist for PHP 7.3. Upgrade your PHP to at least 7.4 and run composer update to apply security fixes."
+            }
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| :ticket: Issue | IBX-11405 |
|----------------|-----------|

#### Description:
Composer refuses to resolve packages with known vulnerabilities. phpoffice/phpspreadsheet has vulnerabilities, but they are not fixed for PHP 7.3. We are supporting PHP 7.3 in DXP v3.3 until EOL at end of June.

We could fork PhpSpreadSheet, backport the fixes, and maintain it for the 4 months left until v3.3 EOL. The effort is major and unreasonable, considering that users can resolve it by upgrading their PHP to 7.4 and running composer update to get a newer phpspreadsheet.

Hence we will unblock this by using composer audit ignore on phpspreadsheet in DXP v3.3. Our limited resources are better spent on other things.

**DO NOT MERGE THIS UP! It's for v3.3 only.**